### PR TITLE
Final update for 2.05

### DIFF
--- a/DHCP_Inventory_V2_ReadMe.rtf
+++ b/DHCP_Inventory_V2_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -93,14 +93,14 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid154156
 \rsid223821\rsid288140\rsid610283\rsid1860407\rsid2049824\rsid2120254\rsid2516050\rsid3830441\rsid4141265\rsid4409828\rsid4725337\rsid4733042\rsid4810367\rsid4880174\rsid5384286\rsid5399097\rsid5588031\rsid5853019\rsid6317044\rsid6557588\rsid7082315
-\rsid7482831\rsid7553723\rsid7885078\rsid9264227\rsid9334467\rsid9451587\rsid9460937\rsid9531606\rsid9649819\rsid10290913\rsid10816165\rsid10824002\rsid11142684\rsid11488686\rsid11602030\rsid11807305\rsid12072617\rsid12196856\rsid12612347\rsid12916989
-\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14501763\rsid14511311\rsid14697282\rsid14893653\rsid15008361\rsid15340208\rsid15549553\rsid15812067\rsid15876253\rsid16057654
-\rsid16149376\rsid16203426\rsid16342768\rsid16463664\rsid16646167\rsid16661544}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo9\dy11\hr15\min24}{\version53}{\edmins468}{\nofpages21}{\nofwords5762}{\nofchars32844}{\nofcharsws38529}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid7482831\rsid7553723\rsid7885078\rsid9264227\rsid9334467\rsid9451587\rsid9460937\rsid9531606\rsid9649819\rsid10290913\rsid10579277\rsid10816165\rsid10824002\rsid11142684\rsid11488686\rsid11602030\rsid11807305\rsid12072617\rsid12196856\rsid12612347
+\rsid12916989\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14501763\rsid14511311\rsid14697282\rsid14893653\rsid15008361\rsid15340208\rsid15549553\rsid15812067\rsid15876253
+\rsid16057654\rsid16149376\rsid16203426\rsid16342768\rsid16463664\rsid16646167\rsid16661544}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo2\dy17\hr15\min8}{\version54}{\edmins470}{\nofpages21}{\nofwords5763}{\nofchars32850}{\nofcharsws38536}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzI3NTQ0NzA3NDA2NTFX0lEKTi0uzszPAykwNK0FAOVI/7gtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzI3NTQ0NzA3NDA2NTFX0lEKTi0uzszPAykwNKsFACYb0pMtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -319,13 +319,13 @@ Before we start using PowerShell to document anything in }{\rtlch\fcs1 \af37\afs
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16646167 \hich\af37\dbch\af31505\loch\f37 HYPERLINK\hich\af37\dbch\af31505\loch\f37  "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16646167 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005cba}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid16646167\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Wind\hich\af37\dbch\af31505\loch\f37 ows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005cba00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid16646167\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Win\hich\af37\dbch\af31505\loch\f37 dows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16646167 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16646167 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field\flddirty{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16646167 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16646167 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003001300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030013006f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid16646167\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16646167 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -333,8 +333,8 @@ Before we start using PowerShell to document anything in }{\rtlch\fcs1 \af37\afs
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLI\hich\af37\dbch\af31505\loch\f37 NK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f003432750100000000a300742e000000000049fd}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\fs22\ul\cf1\insrsid12196856 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for\hich\af43\dbch\af31505\loch\f43  Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f003432750100000000a300742e000000000049fd00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for\hich\af43\dbch\af31505\loch\f43  Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 PowerShell 3.0 or higher is required.
@@ -458,41 +458,41 @@ dhcp_inventory_V2.ps1 [-ComputerName <String>] [-AllDHCPServers] [-HTML] }{\rtlc
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/\hich\af2\dbch\af31505\loch\f2 d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00030077}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com\hich\af2\dbch\af31505\loch\f2 /d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/\hich\af2\dbch\af31505\loch\f2 d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030077}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com\hich\af2\dbch\af31505\loch\f2 /d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003b5}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003b500}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008, and 2008 R2, use the following to export and import the
 \par \hich\af2\dbch\af31505\loch\f2     DHCP data:
-\par \hich\af2\dbch\af31505\loch\f2         Export from the 2003, \hich\af2\dbch\af31505\loch\f2 2008, or 2008 R2 server:
+\par \hich\af2\dbch\af31505\loch\f2         Export from the 2003,\hich\af2\dbch\af31505\loch\f2  2008, or 2008 R2 server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server export C:\\DHCPExport.txt all
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Copy the C:\\DHCPExport.txt file to the 2012+ server.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Import on the 2012+ server:
-\par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server import c:\\DHCPExport.txt al\hich\af2\dbch\af31505\loch\f2 l
+\par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server import c:\\DHCPExport.txt a\hich\af2\dbch\af31505\loch\f2 ll
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The script can now be run on the 2012+ DHCP server to document the older DHCP
 \par \hich\af2\dbch\af31505\loch\f2         information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2008 and Server 2008 R2, the 2012+ DHCP Server PowerShell cmdlets
 \par \hich\af2\dbch\af31505\loch\f2     can be used for export and import.
-\par \hich\af2\dbch\af31505\loch\f2         From the \hich\af2\dbch\af31505\loch\f2 2012+ DHCP server:
+\par \hich\af2\dbch\af31505\loch\f2         From the\hich\af2\dbch\af31505\loch\f2  2012+ DHCP server:
 \par \hich\af2\dbch\af31505\loch\f2                 Export-DhcpServer -ComputerName 2008R2Server.domain.tld -Leases -File
 \par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml
 \par 
@@ -562,27 +562,27 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Cr\hich\af2\dbch\af31505\loch\f2 eates a formatted text file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    na\hich\af2\dbch\af31505\loch\f2 med
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the sc\hich\af2\dbch\af31505\loch\f2 ript runs from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script runs from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e., Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter adds to both the time it takes to run the script \hich\af2\dbch\af31505\loch\f2 and
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Selecting this parameter adds to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -595,23 +595,23 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeLeases [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Include DHCP lease information.
-\par \hich\af2\dbch\af31505\loch\f2         The default is to not included lease in\hich\af2\dbch\af31505\loch\f2 formation.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Include DHCP lease information.
+\par \hich\af2\dbch\af31505\loch\f2         The default is to not included lease information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -IncludeOptions [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -IncludeOptions [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Include DHCP Options information.
 \par \hich\af2\dbch\af31505\loch\f2         The default is to not included Options information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
@@ -619,24 +619,24 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will either be:
-\par \hich\af2\dbch\af31505\loch\f2                 DHCP Inventory Report for Server <server> for the Domain <domain>_2021-06-01_1800.html (or .t\hich\af2\dbch\af31505\loch\f2 xt or .docx or .pdf)
+\par \hich\af2\dbch\af31505\loch\f2                 DHCP Inventory Report for Server <\hich\af2\dbch\af31505\loch\f2 server> for the Domain <domain>_2021-06-01_1800.html (or .txt or .docx or .pdf)
 \par \hich\af2\dbch\af31505\loch\f2                 DHCP Inventory for All DHCP Servers for the Domain <domain>_2021-06-01_1800.html (or .txt or .docx or .pdf)
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?   \hich\af2\dbch\af31505\loch\f2                  named
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all \hich\af2\dbch\af31505\loch\f2 errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Clears \hich\af2\dbch\af31505\loch\f2 errors at the beginning of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the\hich\af2\dbch\af31505\loch\f2  script runs.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by defaul\hich\af2\dbch\af31505\loch\f2 t.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -671,31 +671,31 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has a\hich\af2\dbch\af31505\loch\f2 n alias of RF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of RF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Report Footer
 \par \hich\af2\dbch\af31505\loch\f2                 Report information:
 \par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
 \par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
-\par \hich\af2\dbch\af31505\loch\f2                         Started on \hich\af2\dbch\af31505\loch\f2 <Date Time in Local Format>
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in\hich\af2\dbch\af31505\loch\f2  Local Format>
 \par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Scrip\hich\af2\dbch\af31505\loch\f2 t Name and Script Release date are script-specific variables.
+\par \hich\af2\dbch\af31505\loch\f2         Script Name and Sc\hich\af2\dbch\af31505\loch\f2 ript Release date are script-specific variables.
 \par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a cal}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2 c}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \hich\af2\dbch\af31505\loch\f2 ulated value.
 \par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
 \par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
-\par \hich\af2\dbch\af31505\loch\f2         Fo\hich\af2\dbch\af31505\loch\f2 lder Name is a script variable.
+\par \hich\af2\dbch\af31505\loch\f2         Folder Name is \hich\af2\dbch\af31505\loch\f2 a script variable.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -933,8 +933,8 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00035c}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00035c5c}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe objects to this script.
@@ -949,23 +949,23 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DHCP_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.04
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10579277 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10824002 \hich\af2\dbch\af31505\loch\f2 September 11, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10579277 \hich\af2\dbch\af31505\loch\f2 February 17, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -ComputerName DHCPServer01 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for t\hich\af2\dbch\af31505\loch\f2 he User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script runs remotely against the DHCP server DHCPServer01.
 \par 
@@ -1147,8 +1147,8 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date Timestamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     July 25, 2021 at 6PM is 2\hich\af2\dbch\af31505\loch\f2 021-07-25_1800.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_\hich\af2\dbch\af31505\loch\f2 HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     July 25, 2021 at 6PM is 2021-07-25_1800.
 \par \hich\af2\dbch\af31505\loch\f2     The output filename will be DHCP Inventory Report for Server <server> for the Domain
 \par \hich\af2\dbch\af31505\loch\f2     <domain>_2021-07-25_1800.pdf
 \par 
@@ -1157,70 +1157,72 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V\hich\af2\dbch\af31505\loch\f2 2.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 >PS C:\\PSScript .\\DHCP_Inventory_V2.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker
 \par \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes\hich\af2\dbch\af31505\loch\f2  Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for\hich\af2\dbch\af31505\loch\f2  the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Compa\hich\af2\dbch\af31505\loch\f2 ny Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V2.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V2.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
 \par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the C\hich\af2\dbch\af31505\loch\f2 over Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com for the Company Email.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -Folder \\\\FileServer\\\hich\af2\dbch\af31505\loch\f2 ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output HTML file will be saved in the path \\\\\hich\af2\dbch\af31505\loch\f2 FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output HTML file will be saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -HTML -MSWord -PDF -Text -Dev -ScriptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V2.ps1 -HTML -MSWord -PDF -Text -Dev -ScriptInfo -Log
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptErrors_yyyy-MM-dd_HHmm for the Domain
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptErrors_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10579277\charrsid10579277 \hich\af2\dbch\af31505\loch\f2 yyyyMMddTHHmmssffff}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2  for the Domain
 \par \hich\af2\dbch\af31505\loch\f2     <domain>.txt that contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a tex\hich\af2\dbch\af31505\loch\f2 t file named DHCPInventoryScriptInfo_yyyy-MM-dd_HHmm for the Domain
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptInfo_\hich\af2\dbch\af31505\loch\f2 yyyy-MM-dd_HHmm\hich\af2\dbch\af31505\loch\f2  for the Domain
 \par \hich\af2\dbch\af31505\loch\f2     <domain>.txt that contains all the script parameters and other basic information.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
-\par \hich\af2\dbch\af31505\loch\f2     DHCPDocScriptTranscript_yyyy-MM-dd_HHmm for \hich\af2\dbch\af31505\loch\f2 the Domain <domain>.txt.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Creates a text file for transcript logging named
+\par \hich\af2\dbch\af31505\loch\f2     DHCPDocScriptTranscript_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10579277\charrsid10579277 \hich\af2\dbch\af31505\loch\f2 yyyyMMddTHHmmssffff}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2  for the Domain <domain>.txt.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNam\hich\af2\dbch\af31505\loch\f2 e="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Ca\hich\af2\dbch\af31505\loch\f2 rl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User \hich\af2\dbch\af31505\loch\f2 Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script runs remotely against the DHCP server DHCPServer.
 \par 
@@ -1229,29 +1231,29 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -SmtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V2.ps1 -SmtpServer mail.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending\hich\af2\dbch\af31505\loch\f2  from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the defaul\hich\af2\dbch\af31505\loch\f2 t SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email,
-\par \hich\af2\dbch\af31505\loch\f2     the script prompts the user to enter valid credentia\hich\af2\dbch\af31505\loch\f2 ls.
+\par \hich\af2\dbch\af31505\loch\f2     the script prompts the user to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSSc\hich\af2\dbch\af31505\loch\f2 ript >.\\DHCP_Inventory_V2.ps1 -SmtpServer mailrelay.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     T\hich\af2\dbch\af31505\loch\f2 he script uses the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld,\hich\af2\dbch\af31505\loch\f2  sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
 \par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
@@ -1262,19 +1264,19 @@ HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000369}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000369a6}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300c9}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script\hich\af2\dbch\af31505\loch\f2  generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
@@ -1283,21 +1285,20 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -SmtpServer
-\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook\hich\af2\dbch\af31505\loch\f2 .com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-s\hich\af2\dbch\af31505\loch\f2 end-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 
-{\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.mic\hich\af2\dbch\af31505\loch\f2 
+rosoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000301}}}{\fldrslt {\rtlch\fcs1 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030100}}}{\fldrslt {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12612347\charrsid12612347 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
 }}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12612347\charrsid12612347 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     Thi\hich\af2\dbch\af31505\loch\f2 s uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
@@ -1309,13 +1310,13 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.offic\hich\af2\dbch\af31505\loch\f2 e365.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending \hich\af2\dbch\af31505\loch\f2 to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email,
 \par \hich\af2\dbch\af31505\loch\f2     the script prompts the user to enter valid credentials.
@@ -1323,9 +1324,9 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------\hich\af2\dbch\af31505\loch\f2 ------------------- EXAMPLE 22 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V2.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\D\hich\af2\dbch\af31505\loch\f2 HCP_Inventory_V2.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
@@ -1506,8 +1507,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000010dc
-caf54aa7d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000070c9
+04954224d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DHCP_Script_ChangeLog.txt
+++ b/DHCP_Script_ChangeLog.txt
@@ -8,6 +8,23 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 2.05 17-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 2.04 11-Sep-2021
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables
 #	Added Function OutputReportFooter


### PR DESCRIPTION
#Version 2.05 17-Feb-2022
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file